### PR TITLE
Fixed a Dockerfile, also your node is filled with deprecated/vulnerability warnings

### DIFF
--- a/docker-api/.dockerignore
+++ b/docker-api/.dockerignore
@@ -1,0 +1,2 @@
+Dockerfile
+.gitignore

--- a/docker-api/Dockerfile
+++ b/docker-api/Dockerfile
@@ -3,11 +3,10 @@ WORKDIR /build
 COPY go.mod go.sum ./
 RUN go mod download
 COPY .  .  
-RUN CGO_ENABLED=0 GOOS=linux go build -a -o docker-api .
+RUN CGO_ENABLED=0 go build -a -o docker-api .
 
 FROM docker:20.10.17-alpine3.16
 WORKDIR /api
 COPY --from=build /build .
 EXPOSE 8080
-ENTRYPOINT [ "./docker-api" ]
-CMD [ "3", "300" ]
+ENTRYPOINT ["./docker-api"]


### PR DESCRIPTION
npm WARN deprecated svgo@1.3.2: This SVGO version is no longer supported. Upgrade to v2.x.x.
npm WARN deprecated stable@0.1.8: Modern JS already guarantees Array#sort() is a stable sort, so this library is deprecated. See the compatibility table on MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort#browser_compatibility
npm WARN deprecated source-map-resolve@0.6.0: See https://github.com/lydell/source-map-resolve#deprecated

`24 vulnerabilities (8 moderate, 16 high)`

```
added 1547 packages, and audited 1548 packages in 47s
239 packages are looking for funding
  run `npm fund` for details

9 high severity vulnerabilities
```
I ain't sure what I did wrong but 3, 300 allocations are not a optimization standard anymore so I removed them.


## Ideas
# I highly suggest
-  remove Flask and change it Fast-API, the minimal python api script will get even more tinier and become asynchronous as well. 
- remove run.sh and make a parallel make file










